### PR TITLE
HC-522-update: Updates to the Dockerfile and Manifest init to support moving away from the OPS user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=latest
+ARG TAG=HC-522
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522-update
+ARG TAG=latest
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522
+ARG TAG=HC-522-update
 FROM hysds/dev:${TAG}
 
 # get org and branch
@@ -61,22 +61,22 @@ RUN set -ex \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf
 
-# copy ops home
-COPY --chown=ops:ops --from=0 /home/ops /home/ops
+# copy root
+COPY --chown=root:root --from=0 /root /root
 
 # link configuration files
 RUN set -ex \
- && ln -sf /home/ops/sciflo/etc/celeryconfig.py /home/ops/sciflo/ops/hysds/celeryconfig.py \
- && ln -sf /home/ops/sciflo/etc/grq2_settings.cfg /home/ops/sciflo/ops/grq2/settings.cfg \
- && ln -sf /home/ops/sciflo/etc/pele_settings.cfg /home/ops/sciflo/ops/pele/settings.cfg \
- && ln -sf /home/ops/sciflo/etc/server.key /home/ops/sciflo/ops/grq2/server.key \
- && ln -sf /home/ops/sciflo/etc/server.pem /home/ops/sciflo/ops/grq2/server.pem \
- && ln -sf /home/ops/sciflo/etc/server.key /home/ops/sciflo/ops/pele/server.key \
- && ln -sf /home/ops/sciflo/etc/server.pem /home/ops/sciflo/ops/pele/server.pem
+ && ln -sf $HOME/sciflo/etc/celeryconfig.py $HOME/sciflo/ops/hysds/celeryconfig.py \
+ && ln -sf $HOME/sciflo/etc/grq2_settings.cfg $HOME/sciflo/ops/grq2/settings.cfg \
+ && ln -sf $HOME/sciflo/etc/pele_settings.cfg $HOME/sciflo/ops/pele/settings.cfg \
+ && ln -sf $HOME/sciflo/etc/server.key $HOME/sciflo/ops/grq2/server.key \
+ && ln -sf $HOME/sciflo/etc/server.pem $HOME/sciflo/ops/grq2/server.pem \
+ && ln -sf $HOME/sciflo/etc/server.key $HOME/sciflo/ops/pele/server.key \
+ && ln -sf $HOME/sciflo/etc/server.pem $HOME/sciflo/ops/pele/server.pem
 
 # set default supervisord conf and copy includes
-COPY --chown=ops:ops docker/supervisord.conf /home/ops/sciflo/etc/supervisord.conf
-COPY --chown=ops:ops docker/conf.d /home/ops/sciflo/etc/conf.d
+COPY --chown=root:root docker/supervisord.conf $HOME/sciflo/etc/supervisord.conf
+COPY --chown=root:root docker/conf.d $HOME/sciflo/etc/conf.d
 
 # set entrypoint
 COPY docker/wait-for-it.sh /wait-for-it.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,9 @@ ARG HYSDS_RELEASE=develop
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-grq/git/refs/heads/${BRANCH} version.json
 
+# set HOME explicitly
+ENV HOME /home/ops
+
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
  && sudo chown ops:ops $HOME/.git_oauth_token \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ ADD https://api.github.com/repos/${ORG}/puppet-grq/git/refs/heads/${BRANCH} vers
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
- && sudo chown ops:ops $HOME/.git_oauth_token \
+ && sudo chown root:root $HOME/.git_oauth_token \
  && set -ex \
  && sudo dnf update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,6 @@ ARG HYSDS_RELEASE=develop
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-grq/git/refs/heads/${BRANCH} version.json
 
-# set HOME explicitly
-ENV HOME /home/ops
-
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
  && sudo chown ops:ops $HOME/.git_oauth_token \

--- a/docker/conf.d/inet_http_server.conf
+++ b/docker/conf.d/inet_http_server.conf
@@ -1,4 +1,2 @@
 [inet_http_server]
 port = 0.0.0.0:9001
-username = ops
-password = ops

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # set HOME explicitly
-export HOME=/home/ops
+export HOME=/root
 
 # wait for redis and ES
 /wait-for-it.sh -t 30 grq-redis:6379
@@ -15,14 +15,14 @@ GID=$(id -g)
 gosu 0:0 ssh-keygen -A 2>/dev/null
 
 # update user and group ids
-gosu 0:0 groupmod -g $GID ops 2>/dev/null
-gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-gosu 0:0 usermod -aG docker ops 2>/dev/null
+#gosu 0:0 groupmod -g $GID ops 2>/dev/null
+#gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
+#gosu 0:0 usermod -aG docker ops 2>/dev/null
 
 # update ownership
-gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
 
 # source bash profile
 source $HOME/.bash_profile

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -14,15 +14,10 @@ GID=$(id -g)
 # generate ssh keys
 gosu 0:0 ssh-keygen -A 2>/dev/null
 
-# update user and group ids
-#gosu 0:0 groupmod -g $GID ops 2>/dev/null
-#gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-#gosu 0:0 usermod -aG docker ops 2>/dev/null
-
-# update ownership
-#gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
-#gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
-#gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
+# update ownership of other files
+if [ -e /var/run/docker.sock ]; then
+  gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+fi
 
 # source bash profile
 source $HOME/.bash_profile

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@ class grq inherits hysds_base {
     'httpd': ensure => present;
     'mod_ssl': ensure => present;
     #'mod_evasive': ensure => present;
-    'https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/m/mod_evasive-1.10.1-22.el7.x86_64.rpm': ensure => present;
+    'https://dl.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/m/mod_evasive-1.10.1-22.el7.x86_64.rpm': ensure => present;
     'geos-devel': ensure => installed;
     'proj-devel': ensure => installed;
     #'geos-python': ensure => installed;

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class grq inherits hysds_base {
   # copy user files
   #####################################################
   
-  file { "/home/$user/.bash_profile":
+  file { "/$user/.bash_profile":
     ensure  => present,
     content => template('grq/bash_profile'),
     owner   => $user,
@@ -22,7 +22,7 @@ class grq inherits hysds_base {
   # get sciflo directory
   #####################################################
 
-  $sciflo_dir = "/home/$user/sciflo"
+  $sciflo_dir = "/$user/sciflo"
 
 
   #####################################################
@@ -136,7 +136,7 @@ class grq inherits hysds_base {
   # install install_hysds.sh script in ops home
   #####################################################
 
-  file { "/home/$user/install_hysds.sh":
+  file { "/$user/install_hysds.sh":
     ensure  => present,
     content  => template('grq/install_hysds.sh'),
     owner   => $user,


### PR DESCRIPTION
This PR updates the Dockerfile as well as the init.pp in the puppet manifest to support the moving away from the OPS user in the HySDS Core container. The containers will default to the root user now, where the HySDS Core code will now reside under `/root`.

In addition, the link to the mod_evasive package needed to be updated as it was moved.

For testing, the CircleCI was modified to build containers under the HC-522-update tag and it passed:

![image](https://github.com/user-attachments/assets/74710491-b7d0-44ae-a5e6-7d33f1415cb9)


TODO: Will need to remove kludge once approved: https://github.com/hysds/puppet-grq/compare/docker...HC-522-update?expand=1#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR2