### PR TITLE
hot-fix: Update url to mod-evasive package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@ class grq inherits hysds_base {
     'httpd': ensure => present;
     'mod_ssl': ensure => present;
     #'mod_evasive': ensure => present;
-    'https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/m/mod_evasive-1.10.1-22.el7.x86_64.rpm': ensure => present;
+    'https://dl.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/m/mod_evasive-1.10.1-22.el7.x86_64.rpm': ensure => present;
     'geos-devel': ensure => installed;
     'proj-devel': ensure => installed;
     #'geos-python': ensure => installed;


### PR DESCRIPTION
This PR updates the url to get the mod_evasive rpm. Reason being is that the url was moved to another location. This update was part of https://github.com/hysds/puppet-grq/pull/8, but we want to cut a release soon so this update is needed in order to properly build core.